### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#es7-shim <sup>[![Version Badge][2]][1]</sup>
+# es7-shim <sup>[![Version Badge][2]][1]</sup>
 
 [![npm badge][9]][1]
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
